### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/EarthQuakeOfMCPE/MyPlot/Sc/PlotMain.php
+++ b/src/EarthQuakeOfMCPE/MyPlot/Sc/PlotMain.php
@@ -84,10 +84,7 @@ class PlotMain extends PluginBase implements Listener {
 	 * @see \pocketmine\plugin\PluginBase::onEnable()
 	 */
 	public function onEnable() {
-		if (! file_exists ( $this->getDataFolder () . "config.yml" )) {
-			@mkdir ( $this->getDataFolder () );
-			file_put_contents ( $this->getDataFolder () . "config.yml", $this->getResource ( "config.yml" ) );
-		}
+		$this->saveDefaultConfig();
 		// read restriction
 		// $this->config = yaml_parse(file_get_contents($this->getDataFolder() . "config.yml"));
 		$this->getConfig ()->getAll ();


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
